### PR TITLE
feat: publish to MCP Registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
       packages: write
     outputs:
       version: ${{ steps.version.outputs.version }}
+      released: ${{ steps.version.outputs.released }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,8 +52,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - id: version
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          git fetch --tags
+          LATEST_TAG=$(git tag --sort=-creatordate | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)
+          if [ -z "$LATEST_TAG" ]; then
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          VERSION="${LATEST_TAG#v}"
+          TAG_SHA=$(git rev-list -n 1 "$LATEST_TAG")
+          if [ "$TAG_SHA" = "$GITHUB_SHA" ]; then
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
 
   docker:
     name: Docker
@@ -66,6 +80,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
+      - name: Resolve release version
+        id: version
+        env:
+          RELEASE_VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          if [ -z "$RELEASE_VERSION" ]; then
+            echo "ERROR: needs.release.outputs.version is empty" >&2
+            exit 1
+          fi
+          echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -77,7 +101,43 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:v${{ needs.release.outputs.version }}
+            ghcr.io/${{ github.repository }}:v${{ steps.version.outputs.version }}
+
+  mcp-registry:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    needs: [release, docker]
+    if: needs.release.outputs.released == 'true'
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      VERSION: ${{ needs.release.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+      - name: Stamp version into server.json
+        run: |
+          jq --arg v "$VERSION" \
+            '.version = $v | .packages[0].identifier = "ghcr.io/wyre-technology/avanan-mcp:v" + $v' \
+            server.json > server.json.tmp
+          mv server.json.tmp server.json
+          cat server.json
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish
+      - name: Verify registry listing
+        run: |
+          sleep 5
+          curl -sf "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.wyre-technology/avanan-mcp" \
+            | jq '.servers[]?.server | {name, version}'
 
   deploy:
     name: Deploy to Azure Container Apps

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,13 +1,16 @@
 {
-  "branches": ["main"],
+  "branches": [
+    "main"
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
-    ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md", "package.json"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-    }],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
     "@semantic-release/github"
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,3 +67,4 @@ LABEL org.opencontainers.image.documentation="https://github.com/wyre-technology
 LABEL org.opencontainers.image.url="https://github.com/wyre-technology/mcp-server-checkpoint-avanan/pkgs/container/mcp-server-checkpoint-avanan"
 LABEL org.opencontainers.image.vendor="Wyre Technology"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL io.modelcontextprotocol.server.name="io.github.wyre-technology/avanan-mcp"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.wyre-technology/avanan-mcp",
+  "title": "Avanan",
+  "description": "MCP server for Check Point Harmony Email & Collaboration (Avanan) email security.",
+  "repository": {
+    "url": "https://github.com/wyre-technology/avanan-mcp",
+    "source": "github"
+  },
+  "version": "0.0.0",
+  "websiteUrl": "https://github.com/wyre-technology/avanan-mcp",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/wyre-technology/avanan-mcp:0.0.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "AVANAN_CLIENT_ID",
+          "description": "Avanan / Harmony Email API client ID",
+          "isRequired": true,
+          "format": "string"
+        },
+        {
+          "name": "AVANAN_CLIENT_SECRET",
+          "description": "Avanan / Harmony Email API client secret",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "AVANAN_API_URL",
+          "description": "Avanan API base URL — defaults to the standard Harmony Email endpoint if omitted",
+          "isRequired": false,
+          "format": "string"
+        },
+        {
+          "name": "MCP_TRANSPORT",
+          "description": "Transport mode for the server. Set to 'stdio' for local CLI use; the image defaults to 'http' for gateway hosting.",
+          "isRequired": false,
+          "default": "stdio",
+          "format": "string"
+        },
+        {
+          "name": "AUTH_MODE",
+          "description": "Credential source: 'env' reads vars locally, 'gateway' expects header injection from the WYRE MCP Gateway.",
+          "isRequired": false,
+          "default": "env",
+          "format": "string"
+        },
+        {
+          "name": "LOG_LEVEL",
+          "description": "Log verbosity: debug, info, warn, error",
+          "isRequired": false,
+          "default": "info",
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds server.json (OCI/stdio, name io.github.wyre-technology/avanan-mcp) with Avanan/Harmony Email credential schema.
- Adds io.modelcontextprotocol.server.name label to Dockerfile final stage.
- Wires release.yml: release job emits version + released outputs (released determined by tag at HEAD); docker job resolves version from release outputs (no package.json read, avoiding @semantic-release/git push race); appends mcp-registry job (OIDC publish + verify).

## Test plan
- [ ] Merge to main; semantic-release cuts a version tag.
- [ ] Confirm release job outputs released=true and version=X.Y.Z.
- [ ] Confirm docker job tags ghcr.io image with v$VERSION.
- [ ] Confirm mcp-registry job stamps server.json, validates, publishes via github-oidc, and the verify step lists the server.