### PR TITLE
Add destructive-action warnings to mutating tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run typecheck
+      - name: Lint destructive tool warnings
+        run: node scripts/lint-destructive-warnings.mjs src
       - run: npm run build
       - run: npm test
 

--- a/scripts/lint-destructive-warnings.mjs
+++ b/scripts/lint-destructive-warnings.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Lint MCP tool definitions for missing destructive-action warnings.
+// Usage: node scripts/lint-destructive-warnings.mjs [path ...]
+// Exits 1 if any tool whose name matches a destructive verb lacks both
+// (a) a "⚠ DESTRUCTIVE" or "⚠ HIGH-IMPACT" prefix in its description, AND
+// (b) annotations.destructiveHint: true.
+//
+// Convention: see ~/.claude/skills/mcp-vendor-scaffolding/SKILL.md §2.7b.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const DESTRUCTIVE_VERBS = [
+  'delete', 'remove', 'destroy', 'wipe', 'purge', 'drop',
+  'disable', 'deactivate', 'suspend',
+  'revoke', 'reset_password', 'reset_mfa',
+  'offboard', 'terminate',
+  'archive', 'unarchive',
+  'quarantine_delete', 'quarantine_release',
+];
+
+const SKIP_PATTERNS = [
+  /_dropdown\b/, /_list\b/, /_search\b/, /_get\b/,
+  /quarantine_list/, /quarantine_search/,
+  /messages_blocked/, /clicks_blocked/,
+];
+
+const SKIP_DIRS = new Set(['node_modules', 'dist', '__tests__', '.git', 'docs', 'docs-repo']);
+
+function* walk(dir) {
+  let entries;
+  try { entries = readdirSync(dir); } catch { return; }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) {
+      if (SKIP_DIRS.has(entry)) continue;
+      yield* walk(full);
+    } else if (
+      entry.endsWith('.ts') &&
+      !entry.endsWith('.d.ts') &&
+      !entry.endsWith('.test.ts')
+    ) {
+      yield full;
+    }
+  }
+}
+
+const roots = process.argv.slice(2);
+if (roots.length === 0) roots.push('.');
+
+let violations = 0;
+
+for (const root of roots) {
+  for (const file of walk(resolve(root))) {
+    const src = readFileSync(file, 'utf8');
+    const nameRegex = /name:\s*['"]([a-zA-Z0-9_]+)['"]/g;
+    let match;
+    while ((match = nameRegex.exec(src)) !== null) {
+      const toolName = match[1];
+      const lower = toolName.toLowerCase();
+
+      if (SKIP_PATTERNS.some(p => p.test(lower))) continue;
+      if (!DESTRUCTIVE_VERBS.some(v => lower.includes(v))) continue;
+
+      const window = src.slice(match.index, match.index + 1200);
+      const hasWarningPrefix = /⚠\s*(DESTRUCTIVE|HIGH-IMPACT)/.test(window);
+      const hasDestructiveHint = /destructiveHint\s*:\s*true/.test(window);
+
+      if (!hasWarningPrefix || !hasDestructiveHint) {
+        violations++;
+        const lineNum = src.slice(0, match.index).split('\n').length;
+        const missing = [
+          !hasWarningPrefix && 'description prefix (⚠ DESTRUCTIVE/HIGH-IMPACT)',
+          !hasDestructiveHint && 'annotations.destructiveHint: true',
+        ].filter(Boolean).join(' + ');
+        console.error(`${file}:${lineNum}  ${toolName}  missing: ${missing}`);
+      }
+    }
+  }
+}
+
+if (violations > 0) {
+  console.error(`\n${violations} destructive tool(s) missing warnings.`);
+  console.error('See ~/.claude/skills/mcp-vendor-scaffolding/SKILL.md §2.7b for the convention.');
+  process.exit(1);
+}
+console.log('All destructive tools carry the required warnings.');

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -12,7 +12,16 @@ export const actionTools: Tool[] = [
   {
     name: "hec_quarantine_events",
     description:
-      "Quarantine one or more security events by event ID. Returns task IDs to track progress.",
+      "⚠ HIGH-IMPACT. Quarantine one or more security events by event ID. " +
+      "Quarantining is reversible via restore but affects user access to events. " +
+      "Returns task IDs to track progress. Confirm with the user before invoking.",
+    annotations: {
+      title: "Quarantine events (reversible)",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: "object",
       properties: {
@@ -46,7 +55,16 @@ export const actionTools: Tool[] = [
   {
     name: "hec_quarantine_emails",
     description:
-      "Quarantine specific email entities by entity ID. Returns task IDs to track progress.",
+      "⚠ HIGH-IMPACT. Quarantine specific email entities by entity ID. " +
+      "Quarantining is reversible via restore but affects user access to emails. " +
+      "Returns task IDs to track progress. Confirm with the user before invoking.",
+    annotations: {
+      title: "Quarantine emails (reversible)",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: "object",
       properties: {

--- a/src/tools/exceptions.ts
+++ b/src/tools/exceptions.ts
@@ -91,7 +91,17 @@ export const exceptionTools: Tool[] = [
   },
   {
     name: "hec_delete_exception",
-    description: "Delete a whitelist or blacklist entry by its entity ID.",
+    description:
+      "⚠ DESTRUCTIVE — IRREVERSIBLE. Delete a whitelist or blacklist entry by its entity ID. " +
+      "This action cannot be undone and will permanently remove the exception from security policy. " +
+      "Confirm with the user before invoking.",
+    annotations: {
+      title: "Delete exception (irreversible)",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## Summary
- Apply the WYRE MCP destructive-tool warning convention (§2.7b) to mutating tools: description prefix (`⚠ DESTRUCTIVE — IRREVERSIBLE.` / `⚠ HIGH-IMPACT.`) plus `annotations.destructiveHint: true`.
- Add `scripts/lint-destructive-warnings.mjs` (verbatim copy from mcp-gateway) and wire it into the release workflow right after typecheck so future destructive tools must carry the warnings.

## Affected tools
- `hec_quarantine_events` (Tier B — high-impact)
- `hec_quarantine_emails` (Tier B — high-impact)
- `hec_delete_exception` (Tier A — irreversible)

Read-only and restore/update tools are untouched, per the convention.

## Test plan
- [x] `npx tsc --noEmit` passes locally
- [x] `node scripts/lint-destructive-warnings.mjs src` passes locally
- [ ] CI lint step passes on PR