### PR TITLE
ci: use reusable mcp-server-ci.yml workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,23 +8,14 @@ on:
 
 jobs:
   test:
-    name: Test (Node ${{ matrix.node-version }})
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20, 22]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: npm
-      - run: npm ci
-      - run: npm run typecheck
-      - name: Lint destructive tool warnings
-        run: node scripts/lint-destructive-warnings.mjs src
-      - run: npm run build
-      - run: npm test
+    name: Test
+    # Delegated to the canonical reusable CI workflow.
+    # See: ~/.claude/skills/mcp-server-fleet-ci-template
+    uses: wyre-technology/.github/.github/workflows/mcp-server-ci.yml@cd81e464960d82e07779febbcbf1716e22e408e4
+    with:
+      node-versions: '["20", "22"]'
+      lint-destructive-warnings: true
+    secrets: inherit
 
   release:
     name: Release


### PR DESCRIPTION
Fleet-wide migration to the canonical reusable CI workflow at `wyre-technology/.github`. Behavior identical; eliminates duplicated boilerplate.