### PR TITLE
fix: decouple /health from upstream credential availability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,13 +103,22 @@ async function startHttpTransport(): Promise<void> {
     const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
 
     if (url.pathname === "/health") {
-      const creds = getCredentials();
-      res.writeHead(creds ? 200 : 503, { "Content-Type": "application/json" });
+      // Liveness probe: HTTP server is bound and accepting requests. Always
+      // 200 as long as we got here. In gateway/multi-tenant mode the upstream
+      // creds arrive per-request via headers, so the absence of process-env
+      // creds is normal — gating liveness on them caused a crash-loop on
+      // ACA (probe → 503 → kill → restart → repeat). The diagnostic value
+      // of "are upstream env creds present?" is preserved as a separate
+      // field that operators can inspect without it being load-bearing on
+      // the probe.
+      const hasEnvCreds = !!process.env.CHECKPOINT_CLIENT_ID && !!process.env.CHECKPOINT_CLIENT_SECRET;
+      res.writeHead(200, { "Content-Type": "application/json" });
       res.end(
         JSON.stringify({
-          status: creds ? "ok" : "degraded",
+          status: "ok",
           transport: "http",
           authMode: isGatewayMode ? "gateway" : "env",
+          envCredentialsConfigured: hasEnvCreds,
           version: "2.0.0",
           timestamp: new Date().toISOString(),
         })


### PR DESCRIPTION
## Summary
`/health` was returning **503** whenever `getCredentials()` returned null. In gateway/multi-tenant mode upstream Checkpoint creds arrive per-request via headers (AsyncLocalStorage), so probes like ACA's liveness check naturally hit the endpoint with no request context, got null back, produced 503, ACA killed the container, restart, same thing 30s later → infinite crash-loop.

Observed in prod for hours on \`gwp-avanan\` (both active revisions \`Unhealthy\`). A customer (DN Solutions) was hitting "I have Avanan connected but no tools show up" because \`aggregateTools\` was timing out against the perpetually-restarting container, then silently swallowing the failure (separate gateway-side defect tracked elsewhere).

## Root cause
The handler conflated two different questions:
- **Liveness**: HTTP server bound and accepting. Should always 200 once we got here.
- **Per-request auth**: handled at \`/mcp\` time. Failures there are 401/403, not container death.

## Fix
\`/health\` always returns 200 as long as the request reaches the handler. The "are upstream env creds configured?" diagnostic is preserved as a separate field on the JSON body (\`envCredentialsConfigured: true|false\`) so operators can still see the answer — but it's not load-bearing on the probe.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] After merge + image republish + ACA pull: \`gwp-avanan\` stays Healthy across both revisions, even with no \`CHECKPOINT_CLIENT_ID\` env var set.
- [ ] \`curl /health\` returns 200 with \`envCredentialsConfigured: false\`.
- [ ] \`POST /mcp\` with a valid per-request bearer still works (request-path behavior unchanged).
- [ ] \`POST /mcp\` with no creds still returns a clean error (request-path behavior unchanged).

## Related
- Cross-refs your 2026-04-13 P0 learning ("vendor containers must isolate credentials per-request"). Same anti-pattern; just at the probe endpoint instead of the request path.
- The same audit needs to happen on every other \`*-mcp\` repo in the org. \`grep -rn 'writeHead(503' \` across them should catch others.