### PR TITLE
chore: add eslint config + drop unused import

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-explicit-any": "warn",
+    "no-empty": ["warn", { "allowEmptyCatch": true }]
+  },
+  "ignorePatterns": ["dist/", "node_modules/", "*.config.ts", "*.config.js"]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,6 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "./utils/logger.js";
-import { getCredentials } from "./utils/client.js";
 import { credentialStore } from "./utils/credential-store.js";
 import { eventTools, handleEventTool } from "./tools/events.js";
 import { searchTools, handleSearchTool } from "./tools/search.js";


### PR DESCRIPTION
Unblocks CI. Lint step had no config file, broken since the script was introduced. Adds the standard typescript-eslint setup that matches the devDependencies in package.json. Also drops the now-unused `getCredentials` import from src/index.ts left over from PR #8.