### PR TITLE
build(deps-dev): adopt TypeScript 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@typescript-eslint/parser": "^6.19.0",
         "eslint": "^8.56.0",
         "semantic-release": "^25.0.0",
-        "typescript": "^5.3.3",
+        "typescript": "^6.0.3",
         "vitest": "^1.2.0"
       },
       "engines": {
@@ -9728,9 +9728,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -55,19 +55,31 @@
     "@typescript-eslint/parser": "^6.19.0",
     "eslint": "^8.56.0",
     "semantic-release": "^25.0.0",
-    "typescript": "^5.3.3",
+    "typescript": "^6.0.3",
     "vitest": "^1.2.0"
   },
   "engines": {
     "node": ">=20.0.0"
   },
   "release": {
-    "branches": ["main"],
+    "branches": [
+      "main"
+    ],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
-      ["@semantic-release/npm", { "npmPublish": false }],
+      [
+        "@semantic-release/changelog",
+        {
+          "changelogFile": "CHANGELOG.md"
+        }
+      ],
+      [
+        "@semantic-release/npm",
+        {
+          "npmPublish": false
+        }
+      ],
       "@semantic-release/github"
     ]
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "lib": ["ES2022"],
+    "lib": [
+      "ES2022"
+    ],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
@@ -13,8 +15,17 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": [
+      "node"
+    ],
+    "ignoreDeprecations": "6.0"
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
Fleet TS6 migration (tracker: wyre-technology/mcp-gateway#221). Applied via the ts6-fleet-migration codemod: `types:["node"]` + `ignoreDeprecations:"6.0"` as needed, `typescript ^6.0.3`. Local typecheck (`typecheck`) passed; CI runs full build/test.