### PR TITLE
ci: bump central reusable-workflow pins to Node 24

### DIFF
--- a/.github/workflows/mcp-assert.yml
+++ b/.github/workflows/mcp-assert.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   assert:
-    uses: wyre-technology/.github/.github/workflows/mcp-assert.yml@17b5a183964aa163d82e9f7092186086e97bc70e  # main
+    uses: wyre-technology/.github/.github/workflows/mcp-assert.yml@198605d0575e27374cf9b67fba3aa8c7b91de2c0  # main
     with:
       entry: dist/index.js
       canary-tool: hec_search_emails

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Test
     # Delegated to the canonical reusable CI workflow.
     # See: ~/.claude/skills/mcp-server-fleet-ci-template
-    uses: wyre-technology/.github/.github/workflows/mcp-server-ci.yml@cd81e464960d82e07779febbcbf1716e22e408e4
+    uses: wyre-technology/.github/.github/workflows/mcp-server-ci.yml@198605d0575e27374cf9b67fba3aa8c7b91de2c0
     with:
       node-versions: '["20", "22"]'
       lint-destructive-warnings: true


### PR DESCRIPTION
Repoints the shared `wyre-technology/.github` reusable workflows to commit `198605d`, which bumped every deprecated Node 20 action to a Node 24 build (wyre-technology/.github#24). Mechanical SHA-only change; validated end-to-end on autotask-mcp as the canary (CI + assert + triage + add-to-project all green).