### PR TITLE
ci: re-pin release reusable to GITHUB_TOKEN npm-auth fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
       id-token: write
       security-events: write
-    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@a61021de876d0fd44dac777fa90f963fea25b0c3
+    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@a925b43adb22aa8885b8243e1056e6a42cdce4d1
     with:
       server-name: avanan-mcp
       image-name: ghcr.io/wyre-technology/avanan-mcp


### PR DESCRIPTION
Re-pins the shared `mcp-server-release.yml` reusable workflow from `a61021d` to `a925b43`, picking up wyre-technology/.github#32 (npm auth via `GITHUB_TOKEN` instead of a GitHub App installation token, which the npm registry rejects for cross-repo package reads). Without this, the next real release fails at the Docker image build. CI-only change tracked in wyre-technology/.github#33; this commit cuts no release.