### PR TITLE
fix(security): eliminate module-level derived-token cache to close cross-tenant leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Fixed a cross-tenant credential leak in gateway (multi-tenant) mode.** `src/utils/client.ts` cached the derived OAuth bearer token, scopes, and resolved base URL (fetched from Checkpoint's `/auth/external` and `/v1.0/scopes` endpoints) in module-level variables shared by the whole process. Raw per-request credentials were already correctly isolated per tenant via `AsyncLocalStorage`, but this *derived* layer was not: under concurrent multi-tenant load, one tenant's in-flight token refresh could be overwritten by another tenant's concurrent refresh before the first tenant's request read it back, causing that request to authenticate with — and receive data scoped to — a different tenant's credentials. Confirmed exploitable in production (this sidecar is live in `conduit-prod`).
+  - Fix: the derived token/scopes/baseUrl cache now lives inside the same `AsyncLocalStorage` request context as the raw credentials (`src/utils/credential-store.ts`), via a new `runWithRequestCredentials()` helper used by the gateway HTTP handler. Each gateway request gets its own isolated cache; the stdio/env (single-tenant) code path keeps a lazily-initialized module-level fallback, since there's no concurrent multi-tenant traffic to race in that mode. No module-level mutable state holding tenant-derived secrets remains in the gateway request path.
+  - Added a regression test (`src/utils/client.test.ts`) that deterministically forces two tenants' requests to interleave (via a manually-resolved deferred, not a timer) so tenant B's request runs to completion while tenant A's is still in flight, then asserts the actual token/base URL values each tenant's outbound API call used. The test fails against the pre-fix implementation and passes against the fix.
+
 ### Added
 
 - **Interactive security event card via MCP Apps (SEP-1865).** `hec_get_event` results now render as an interactive card in MCP Apps hosts (Claude Desktop/web, and other hosts advertising the `io.modelcontextprotocol/ui` extension), instead of a wall of JSON. The card shows the event type, severity, state, confidence, SaaS platform, detection time, description, actions already taken, and available remediation. The card is **read-only** — remediation runs through the existing chat tools, never from the card. Non-App hosts are unaffected: the tool's payload is unchanged apart from a new `_card` field.

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "./utils/logger.js";
-import { credentialStore } from "./utils/credential-store.js";
+import { runWithRequestCredentials } from "./utils/credential-store.js";
 import { registerResourceHandlers } from "./resources.js";
 import { eventTools, handleEventTool } from "./tools/events.js";
 import { searchTools, handleSearchTool } from "./tools/search.js";
@@ -172,7 +172,7 @@ async function startHttpTransport(): Promise<void> {
       };
 
       if (gatewayCreds) {
-        credentialStore.run(gatewayCreds, handleMcp);
+        runWithRequestCredentials(gatewayCreds, handleMcp);
       } else {
         handleMcp();
       }

--- a/src/utils/client.test.ts
+++ b/src/utils/client.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the Checkpoint HEC client, in particular the per-request
+ * derived-token isolation added to close a cross-tenant credential leak
+ * (see credential-store.ts's module doc comment for the full writeup).
+ *
+ * Before the fix, refreshToken()/refreshScopes() wrote the bearer token,
+ * scopes, and resolved base URL to module-level `let`s, and apiRequest()
+ * read them back from those same module-level variables after `await
+ * ensureAuth()`. Under concurrent multi-tenant load, one tenant's request
+ * could still be suspended inside that await (e.g. mid `refreshScopes()`)
+ * when another tenant's request ran to completion and overwrote the
+ * module-level state — so the first tenant's apiRequest() would then read
+ * back the second tenant's live bearer token and base URL.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { apiRequest, getCredentials, clearCredentials } from "./client.js";
+import { runWithRequestCredentials } from "./credential-store.js";
+import { REGIONAL_BASE_URLS } from "./types.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Checkpoint client", () => {
+  const originalEnv = process.env;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    clearCredentials();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+    clearCredentials();
+  });
+
+  describe("getCredentials", () => {
+    it("returns null when no credentials are configured", () => {
+      delete process.env.CHECKPOINT_CLIENT_ID;
+      delete process.env.CHECKPOINT_CLIENT_SECRET;
+      expect(getCredentials()).toBeNull();
+    });
+
+    it("reads credentials from environment variables", () => {
+      process.env.CHECKPOINT_CLIENT_ID = "env-client-id";
+      process.env.CHECKPOINT_CLIENT_SECRET = "env-client-secret";
+      process.env.CHECKPOINT_REGION = "eu";
+
+      expect(getCredentials()).toEqual({
+        clientId: "env-client-id",
+        clientSecret: "env-client-secret",
+        region: "eu",
+      });
+    });
+
+    it("prefers per-request (gateway) credentials over environment variables", () => {
+      process.env.CHECKPOINT_CLIENT_ID = "env-client-id";
+      process.env.CHECKPOINT_CLIENT_SECRET = "env-client-secret";
+
+      const result = runWithRequestCredentials(
+        { clientId: "gw-client-id", clientSecret: "gw-client-secret", region: "us" },
+        () => getCredentials()
+      );
+
+      expect(result).toEqual({
+        clientId: "gw-client-id",
+        clientSecret: "gw-client-secret",
+        region: "us",
+      });
+    });
+  });
+
+  describe("cross-tenant isolation under concurrent load (regression)", () => {
+    // Two tenants with distinct credentials/regions, so a leaked token,
+    // scope list, or base URL is unambiguously attributable to the wrong
+    // tenant if it appears in the other tenant's request.
+    const credsA = { clientId: "tenant-a-id", clientSecret: "tenant-a-secret", region: "us" };
+    const credsB = { clientId: "tenant-b-id", clientSecret: "tenant-b-secret", region: "eu" };
+
+    it("does not let tenant B's fully-completed refresh clobber tenant A's in-flight request", async () => {
+      // Deterministic interleave via a manually-resolved deferred — not a
+      // setTimeout stagger. Tenant A's *scopes* fetch (the step between
+      // "token written" and "apiRequest reads it back") is gated so we
+      // control exactly when it's allowed to resume. While it's parked
+      // there, tenant B's entire request — auth, scopes, and its real API
+      // call — is run to completion and awaited in full. Only then do we
+      // release tenant A. If any derived state (token/baseUrl/scopes) is
+      // shared instead of per-request, tenant A's request will observe
+      // tenant B's values at the point it finally resumes.
+      let releaseTenantAScopes!: () => void;
+      const tenantAScopesGate = new Promise<void>((resolve) => {
+        releaseTenantAScopes = resolve;
+      });
+
+      const apiCalls: Array<{ tag: string; url: string; authorization: string }> = [];
+
+      global.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = input.toString();
+        const headers = (init?.headers ?? {}) as Record<string, string>;
+
+        if (url.includes("/auth/external")) {
+          const body = JSON.parse(String(init?.body ?? "{}")) as { clientId: string };
+          return jsonResponse(200, {
+            success: true,
+            data: { token: `token-for-${body.clientId}`, expiresIn: 1800 },
+          });
+        }
+
+        if (url.includes("/v1.0/scopes")) {
+          const token = headers.Authorization?.replace("Bearer ", "") ?? "";
+          if (token === `token-for-${credsA.clientId}`) {
+            // Park tenant A's scopes fetch here until the test releases it.
+            await tenantAScopesGate;
+          }
+          return jsonResponse(200, {
+            responseEnvelope: { requestId: "req-1", responseCode: 200, responseText: "OK" },
+            responseData: [`farm:${token}`],
+          });
+        }
+
+        // The actual HEC API call — record exactly what credentials/baseUrl
+        // this in-flight request used, tagged by which token it authenticated with.
+        const authorization = headers.Authorization ?? "";
+        apiCalls.push({
+          tag: authorization.includes(credsA.clientId) ? "A" : "B",
+          url,
+          authorization,
+        });
+        return jsonResponse(200, {
+          responseEnvelope: { requestId: "req-2", responseCode: 200, responseText: "OK" },
+          responseData: [],
+        });
+      });
+
+      // Kick off tenant A. It will resolve its own auth fetch (ungated),
+      // write its own token, then block inside refreshScopes()'s fetch call
+      // on tenantAScopesGate — i.e. it is suspended *after* writing its
+      // token but *before* apiRequest() reads it back.
+      const runA = runWithRequestCredentials(credsA, () => apiRequest("/search/query"));
+
+      // Tenant B's entire request — auth, scopes, and its real API call —
+      // is run to completion and awaited in full while tenant A sits
+      // parked at the gate above.
+      const resultB = await runWithRequestCredentials(credsB, () => apiRequest("/search/query"));
+
+      // Only now release tenant A. Under the pre-fix, module-level-cache
+      // implementation, the shared state has since been overwritten by
+      // tenant B's completed run, so tenant A's apiRequest() would read
+      // tenant B's token and base URL here.
+      releaseTenantAScopes();
+      const resultA = await runA;
+
+      // Every assertion below runs unconditionally after both real awaits
+      // above resolved — nothing is swallowed or gated behind a callback
+      // that could silently never fire.
+      expect(resultA).toBeDefined();
+      expect(resultB).toBeDefined();
+      expect(apiCalls).toHaveLength(2);
+
+      const callForA = apiCalls.find((c) => c.tag === "A");
+      const callForB = apiCalls.find((c) => c.tag === "B");
+      expect(callForA).toBeDefined();
+      expect(callForB).toBeDefined();
+
+      // Value assertions, not identity checks: each tenant's actual HEC API
+      // call must carry *its own* bearer token and *its own* region's base
+      // URL — never the other tenant's, even though tenant B's refresh ran
+      // to completion while tenant A's request was still in flight.
+      expect(callForA!.authorization).toBe(`Bearer token-for-${credsA.clientId}`);
+      expect(callForB!.authorization).toBe(`Bearer token-for-${credsB.clientId}`);
+
+      expect(callForA!.url.startsWith(REGIONAL_BASE_URLS.us)).toBe(true);
+      expect(callForB!.url.startsWith(REGIONAL_BASE_URLS.eu)).toBe(true);
+
+      // Sanity: the two tenants' tokens/base URLs are genuinely different,
+      // so the assertions above couldn't pass by coincidence.
+      expect(callForA!.authorization).not.toBe(callForB!.authorization);
+      expect(REGIONAL_BASE_URLS.us).not.toBe(REGIONAL_BASE_URLS.eu);
+    });
+  });
+});

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -17,20 +17,30 @@
 
 import { randomUUID } from "node:crypto";
 import { logger } from "./logger.js";
-import { getRequestCredentials } from "./credential-store.js";
+import {
+  getRequestCredentials,
+  getRequestTokenState,
+  createDerivedTokenState,
+  type DerivedTokenState,
+} from "./credential-store.js";
 import type { CheckpointCredentials, ApiResponse } from "./types.js";
 import { REGIONAL_BASE_URLS, DEFAULT_BASE_URL } from "./types.js";
 
 const AUTH_PATH = "/auth/external";
 const SCOPES_PATH = "/app/hec-api/v1.0/scopes";
 
-// Cached per-process state (invalidated when credentials change)
-let _token: string | null = null;
-let _tokenExpiresAt: number = 0;
-// All scopes available for this key (farm:customer pairs)
-let _scopes: string[] = [];
-let _baseUrl: string = DEFAULT_BASE_URL;
-let _lastCredentials: CheckpointCredentials | null = null;
+// Fallback derived-token cache for stdio/env mode only, where a single
+// process serves exactly one tenant's credentials for its entire lifetime
+// (there is no concurrent multi-tenant traffic to race). Gateway (HTTP,
+// multi-tenant) mode never touches this: it gets its own per-request
+// DerivedTokenState from credential-store.ts's AsyncLocalStorage instead,
+// so concurrent tenants can never observe or overwrite each other's
+// token/scopes/baseUrl.
+let _fallbackTokenState: DerivedTokenState = createDerivedTokenState();
+
+function getTokenState(): DerivedTokenState {
+  return getRequestTokenState() ?? _fallbackTokenState;
+}
 
 /**
  * Get credentials from the per-request store (gateway mode) or
@@ -66,11 +76,11 @@ export function getCredentials(): CheckpointCredentials | null {
   };
 }
 
-function credentialsChanged(creds: CheckpointCredentials): boolean {
-  if (!_lastCredentials) return true;
+function credentialsChanged(creds: CheckpointCredentials, state: DerivedTokenState): boolean {
+  if (!state.lastCredentials) return true;
   return (
-    creds.clientId !== _lastCredentials.clientId ||
-    creds.clientSecret !== _lastCredentials.clientSecret
+    creds.clientId !== state.lastCredentials.clientId ||
+    creds.clientSecret !== state.lastCredentials.clientSecret
   );
 }
 
@@ -85,7 +95,7 @@ function decodeJwtRegion(token: string): string | null {
   }
 }
 
-async function refreshToken(creds: CheckpointCredentials): Promise<void> {
+async function refreshToken(creds: CheckpointCredentials, state: DerivedTokenState): Promise<void> {
   const authUrl = `${DEFAULT_BASE_URL}${AUTH_PATH}`;
   logger.debug("Requesting Checkpoint auth token", { authUrl });
 
@@ -113,19 +123,22 @@ async function refreshToken(creds: CheckpointCredentials): Promise<void> {
   const token = data?.token as string;
   if (!token) throw new Error("Auth response missing token");
 
-  _token = token;
+  // `state` was captured by the caller before this function's first await,
+  // so this write always lands on the request that requested it — even if
+  // another tenant's refreshToken() call resolves in between.
+  state.token = token;
   const expiresIn = (data.expiresIn as number) || 1800;
-  _tokenExpiresAt = Date.now() + expiresIn * 1000;
+  state.tokenExpiresAt = Date.now() + expiresIn * 1000;
 
   const region = creds.region || decodeJwtRegion(token);
-  _baseUrl = (region && REGIONAL_BASE_URLS[region]) || DEFAULT_BASE_URL;
-  logger.debug("Auth token obtained", { region, baseUrl: _baseUrl });
+  state.baseUrl = (region && REGIONAL_BASE_URLS[region]) || DEFAULT_BASE_URL;
+  logger.debug("Auth token obtained", { region, baseUrl: state.baseUrl });
 }
 
-async function fetchScopesFromUrl(baseUrl: string): Promise<string[]> {
+async function fetchScopesFromUrl(baseUrl: string, token: string): Promise<string[]> {
   const res = await fetch(`${baseUrl}${SCOPES_PATH}`, {
     headers: {
-      Authorization: `Bearer ${_token!}`,
+      Authorization: `Bearer ${token}`,
       "x-av-req-id": randomUUID(),
       Accept: "application/json",
     },
@@ -138,45 +151,52 @@ async function fetchScopesFromUrl(baseUrl: string): Promise<string[]> {
   );
 }
 
-async function refreshScopes(): Promise<void> {
-  if (!_token) return;
+async function refreshScopes(state: DerivedTokenState): Promise<void> {
+  if (!state.token) return;
 
   // Try the detected region first
-  let scopes = await fetchScopesFromUrl(_baseUrl);
+  let scopes = await fetchScopesFromUrl(state.baseUrl, state.token);
 
   // If no valid scopes, the JWT region claim may be wrong — try all other regions
   if (scopes.length === 0) {
-    logger.warn("No scopes at detected region, probing all regions", { detected: _baseUrl });
+    logger.warn("No scopes at detected region, probing all regions", { detected: state.baseUrl });
     for (const [region, url] of Object.entries(REGIONAL_BASE_URLS)) {
-      if (url === _baseUrl) continue;
-      scopes = await fetchScopesFromUrl(url);
+      if (url === state.baseUrl) continue;
+      scopes = await fetchScopesFromUrl(url, state.token);
       if (scopes.length > 0) {
         logger.info("Found scopes at alternate region", { region, url, scopes });
-        _baseUrl = url;
+        state.baseUrl = url;
         break;
       }
     }
   }
 
-  _scopes = scopes;
-  logger.debug("Scopes fetched", { scopes: _scopes, baseUrl: _baseUrl });
+  state.scopes = scopes;
+  logger.debug("Scopes fetched", { scopes: state.scopes, baseUrl: state.baseUrl });
 }
 
-async function ensureAuth(): Promise<void> {
+async function ensureAuth(): Promise<DerivedTokenState> {
   const creds = getCredentials();
   if (!creds) throw new Error("No Checkpoint credentials configured");
 
-  if (credentialsChanged(creds)) {
-    _token = null;
-    _tokenExpiresAt = 0;
-    _scopes = [];
-    _lastCredentials = creds;
+  // Captured once, up front — every read/write below (including across
+  // awaits in refreshToken/refreshScopes) goes through this same object
+  // reference, which is exclusive to this request context.
+  const state = getTokenState();
+
+  if (credentialsChanged(creds, state)) {
+    state.token = null;
+    state.tokenExpiresAt = 0;
+    state.scopes = [];
+    state.lastCredentials = { clientId: creds.clientId, clientSecret: creds.clientSecret };
   }
 
-  if (!_token || Date.now() >= _tokenExpiresAt - 60_000) {
-    await refreshToken(creds);
-    await refreshScopes();
+  if (!state.token || Date.now() >= state.tokenExpiresAt - 60_000) {
+    await refreshToken(creds, state);
+    await refreshScopes(state);
   }
+
+  return state;
 }
 
 /**
@@ -193,16 +213,16 @@ export async function apiRequest<T>(
     params?: Record<string, string | number | boolean | undefined>;
   } = {}
 ): Promise<ApiResponse<T>> {
-  await ensureAuth();
+  const state = await ensureAuth();
 
-  if (_scopes.length === 0) {
+  if (state.scopes.length === 0) {
     logger.warn(
       "No HEC scopes available for this key — key may lack farm association. " +
       "Call /v1.0/scopes to diagnose. Expected format: farm:customer (e.g. mt-prod-cp-eu-1:myorg)"
     );
   }
 
-  const url = new URL(`${_baseUrl}/app/hec-api${path}`);
+  const url = new URL(`${state.baseUrl}/app/hec-api${path}`);
   if (options.params) {
     for (const [k, v] of Object.entries(options.params)) {
       if (v !== undefined) url.searchParams.set(k, String(v));
@@ -211,7 +231,7 @@ export async function apiRequest<T>(
 
   const method = options.method ?? "GET";
   const headers: Record<string, string> = {
-    Authorization: `Bearer ${_token!}`,
+    Authorization: `Bearer ${state.token!}`,
     "x-av-req-id": randomUUID(),
     Accept: "application/json",
     "Content-Type": "application/json",
@@ -223,16 +243,16 @@ export async function apiRequest<T>(
     let body = options.body as Record<string, unknown>;
     // For multi-scope keys, inject scopes into requestData so the API can route correctly.
     // Single-scope keys: API picks the only scope automatically when omitted.
-    if (_scopes.length > 1 && body.requestData && typeof body.requestData === "object") {
+    if (state.scopes.length > 1 && body.requestData && typeof body.requestData === "object") {
       body = {
         ...body,
-        requestData: { scopes: _scopes, ...(body.requestData as Record<string, unknown>) },
+        requestData: { scopes: state.scopes, ...(body.requestData as Record<string, unknown>) },
       };
     }
     fetchOptions.body = JSON.stringify(body);
   }
 
-  logger.debug("HEC API request", { method, url: url.toString(), scopes: _scopes });
+  logger.debug("HEC API request", { method, url: url.toString(), scopes: state.scopes });
   const res = await fetch(url.toString(), fetchOptions);
 
   const raw = await res.text();
@@ -245,8 +265,8 @@ export async function apiRequest<T>(
 
   if (!res.ok) {
     if (res.status === 401) {
-      _token = null;
-      _tokenExpiresAt = 0;
+      state.token = null;
+      state.tokenExpiresAt = 0;
     }
 
     // Surface the full responseText for Checkpoint API errors (more informative than message)
@@ -264,8 +284,8 @@ export async function apiRequest<T>(
 }
 
 export function clearCredentials(): void {
-  _token = null;
-  _tokenExpiresAt = 0;
-  _scopes = [];
-  _lastCredentials = null;
+  // Only ever clears the single-tenant fallback (stdio/env mode). Gateway
+  // requests own their DerivedTokenState for the life of the request only —
+  // there is nothing module-level for a gateway request to clear.
+  _fallbackTokenState = createDerivedTokenState();
 }

--- a/src/utils/credential-store.ts
+++ b/src/utils/credential-store.ts
@@ -5,9 +5,20 @@
  * in headers. Instead of mutating process.env (which is shared across all
  * concurrent requests), we store credentials in AsyncLocalStorage so each
  * request handler sees only its own values.
+ *
+ * This context also carries the *derived* per-tenant OAuth state (bearer
+ * token, scopes, resolved base URL) produced by client.ts's refreshToken()/
+ * refreshScopes(). That derived state used to live in module-level `let`s,
+ * which meant one tenant's in-flight token refresh could be overwritten by
+ * another tenant's concurrent refresh before the first tenant read it back
+ * (a cross-tenant credential leak under concurrent load). Scoping it inside
+ * the same AsyncLocalStorage context as the raw credentials means each
+ * gateway request gets its own isolated token cache, with no shared mutable
+ * state anywhere in the request path.
  */
 
 import { AsyncLocalStorage } from "node:async_hooks";
+import { DEFAULT_BASE_URL } from "./types.js";
 
 export interface RequestCredentials {
   clientId: string;
@@ -15,12 +26,62 @@ export interface RequestCredentials {
   region?: string;
 }
 
-export const credentialStore = new AsyncLocalStorage<RequestCredentials>();
+/**
+ * Derived, per-request OAuth state. Unlike RequestCredentials (set once,
+ * read-only for the life of the request), this is mutated in place as
+ * refreshToken()/refreshScopes() resolve — but because every request gets
+ * its own instance via runWithRequestCredentials(), mutating it in place is
+ * safe: there is nothing else that could ever hold a reference to it.
+ */
+export interface DerivedTokenState {
+  token: string | null;
+  tokenExpiresAt: number;
+  scopes: string[];
+  baseUrl: string;
+  /** clientId/clientSecret this state was derived from, for cache invalidation. */
+  lastCredentials: { clientId: string; clientSecret: string } | null;
+}
+
+export function createDerivedTokenState(): DerivedTokenState {
+  return {
+    token: null,
+    tokenExpiresAt: 0,
+    scopes: [],
+    baseUrl: DEFAULT_BASE_URL,
+    lastCredentials: null,
+  };
+}
+
+interface RequestContext {
+  credentials: RequestCredentials;
+  tokenState: DerivedTokenState;
+}
+
+const credentialStore = new AsyncLocalStorage<RequestContext>();
 
 /**
  * Get credentials from the current request context (AsyncLocalStorage).
  * Returns undefined when called outside an active store.run() scope.
  */
 export function getRequestCredentials(): RequestCredentials | undefined {
-  return credentialStore.getStore();
+  return credentialStore.getStore()?.credentials;
+}
+
+/**
+ * Get the derived-token cache for the current request context.
+ * Returns undefined outside an active store.run() scope (stdio/env mode),
+ * where client.ts falls back to a single-tenant module-level cache instead.
+ */
+export function getRequestTokenState(): DerivedTokenState | undefined {
+  return credentialStore.getStore()?.tokenState;
+}
+
+/**
+ * Run `fn` inside a fresh, isolated request context: its own credentials
+ * and its own derived-token cache, neither of which can be observed or
+ * mutated by any concurrently-running request. Used by gateway (HTTP
+ * multi-tenant) mode.
+ */
+export function runWithRequestCredentials<T>(creds: RequestCredentials, fn: () => T): T {
+  return credentialStore.run({ credentials: creds, tokenState: createDerivedTokenState() }, fn);
 }


### PR DESCRIPTION
## Vulnerability

Raw per-request credentials are already correctly isolated via `AsyncLocalStorage` in `src/utils/client.ts` — that part was fine. The bug is in the *derived* layer: `refreshToken(creds)` fetches a bearer token from Checkpoint's `/auth/external` endpoint (and `refreshScopes()` fetches farm:customer scopes from `/v1.0/scopes`) and wrote the result — token, expiry, scopes, resolved base URL — to module-level `let`s (`_token`, `_tokenExpiresAt`, `_scopes`, `_baseUrl`, `_lastCredentials`). `apiRequest()` then read those same module-level variables directly to build the actual API call.

Under concurrent multi-tenant load — exactly how this gateway sidecar runs — the event loop can interleave: tenant A's `refreshToken()` awaits its fetch, tenant B's `refreshToken()`/`refreshScopes()` runs to completion in the meantime and overwrites the module-level state, and tenant A's `apiRequest()` then reads back tenant B's live bearer token and base URL. A real cross-tenant credential leak, confirmed exploitable — this sidecar is live in `conduit-prod` (verified via `az containerapp list`).

Same bug class already found and fixed today in `liongard-mcp#58`, `ninjaone-mcp#71`, `pax8-mcp#38`, and `rootly-mcp#48`.

## Fix

Moved the derived token/scopes/baseUrl cache into the same `AsyncLocalStorage` request context that already holds the raw per-request credentials (`src/utils/credential-store.ts`), via a new `runWithRequestCredentials()` helper that the gateway HTTP handler (`src/index.ts`) now uses instead of calling `credentialStore.run()` directly. Each gateway request gets its own isolated `DerivedTokenState` object; `client.ts`'s `refreshToken()`/`refreshScopes()`/`apiRequest()` now thread that object through explicitly (captured once, up front, before any `await`) instead of touching module state.

ALS was the right call here (over pure parameter-threading) because the raw-credential ALS context was already wired through `getCredentials()`/`getRequestCredentials()` — extending it to also carry the derived cache was the lowest-blast-radius change, touching only `client.ts`, `credential-store.ts`, and the one gateway call site in `index.ts`. No domain/tool handler files needed changes.

The stdio/env (single-tenant) path keeps a lazily-initialized module-level fallback cache — there's no concurrent multi-tenant traffic to race there, matching the precedent in the sibling repos. **No module-level mutable state holding tenant-derived secrets remains in the gateway request path.**

## Test plan

- [x] `npm run typecheck` (`tsc --noEmit`) — clean
- [x] `npm run lint` (eslint) — clean (1 pre-existing, unrelated warning in `exceptions.ts`)
- [x] `npm run build` — clean
- [x] `npm test` — 22/22 pass
- [x] New regression test (`src/utils/client.test.ts`) uses a deterministic interleave — a manually-resolved deferred promise, not a `setTimeout` stagger — to force tenant B's entire request (refresh + scopes + real API call) to run to completion and be fully awaited while tenant A's request is deliberately parked mid-flight (inside its scopes fetch, the exact gap between "token written" and "apiRequest reads it back"). Assertions check the actual bearer-token and base-URL **values** each tenant's outbound API call used (`toBe`/`toEqual` on real values), not object identity.
- [x] Verified the test actually catches the bug: temporarily reintroduced the module-level-cache bug in `client.ts` (kept the new ALS plumbing, but made `getTokenState()` always return the shared fallback) and reran the suite — the new test failed loudly (`expected undefined to be defined`, tenant A's API call was never observed because both calls carried tenant B's token). Re-applied the real fix and reran — all 22 tests green again.

**Not merging this myself** — leaving open for review (boss + warden for the security/credential-handling review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)