### PR TITLE
fix(security): enforce gateway S2S verification (gateway#377 parity)

### DIFF
--- a/src/__tests__/s2s-guard-ordering.test.ts
+++ b/src/__tests__/s2s-guard-ordering.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Instrumented call-counter probe for the S2S guard ordering invariant
+ * (boss's ordering-catch rule, 2026-07-28 S2S rollout evidence report).
+ *
+ * A generic 4-case grant/deny test proves the guard rejects/accepts, but not
+ * ORDERING — a sibling whose credential-read has a side effect (here: the
+ * lazy Checkpoint OAuth exchange inside ensureAuth(), see src/utils/client.ts)
+ * could still have that side effect fire on a rejected request if the guard
+ * were ever moved after it. This test spins up the real HTTP handler
+ * (src/index.ts) and asserts Checkpoint's `/auth/external` (refreshToken)
+ * and `/v1.0/scopes` (refreshScopes) endpoints are hit exactly ZERO times
+ * when the S2S guard rejects a request.
+ *
+ * SCOPE NOTE (approach (a), the strongest option offered): unlike blumira's
+ * OAuth exchange (eager, called directly in the HTTP handler before
+ * dispatch), avanan's OAuth call is *lazy* — ensureAuth() (client.ts:178)
+ * only fires from inside apiRequest() (client.ts:216), which only runs when
+ * an actual MCP tool handler executes. Neither ensureAuth() nor
+ * refreshToken()/refreshScopes() are exported from client.ts, so they can't
+ * be vi.mock()'d directly by name. Instead this test drives a REAL
+ * `tools/call` for the lightest available tool (`hec_query_events`, which
+ * takes no required arguments) through the actual HTTP server with valid
+ * S2S + Checkpoint gateway-credential headers, and observes the sole
+ * externally-visible side effect of refreshToken()/refreshScopes() firing:
+ * outbound fetch() calls to Checkpoint's real `/auth/external` and
+ * `/v1.0/scopes` paths (same substring-matching technique already used by
+ * src/utils/client.test.ts's cross-tenant regression test). global.fetch is
+ * mocked with a passthrough for calls to this test's own local HTTP server
+ * (so the test's own request to /mcp is unaffected) and stubbed responses
+ * for the two Checkpoint endpoints plus the underlying HEC data call — this
+ * is a full, real MCP tools/call round-trip through the real SDK server,
+ * not a bypassed unit call, so it counts as the strongest option (a) rather
+ * than the (b) fallback.
+ */
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { createHmac } from "node:crypto";
+
+const TEST_PORT = 47031;
+const TEST_HOST = "127.0.0.1";
+const TEST_SERVER_PREFIX = `http://${TEST_HOST}:${TEST_PORT}`;
+const TEST_S2S_SECRET = "test-s2s-guard-ordering-secret-do-not-use-in-prod";
+
+const originalFetch = global.fetch;
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * A fresh fetch mock per test: passes real requests to this test's own
+ * local HTTP server straight through to the real network, and stubs out
+ * Checkpoint's auth/scopes/data endpoints — while counting calls to each so
+ * tests can assert exactly how many times refreshToken()/refreshScopes()
+ * fired (by way of their fetch() side effects).
+ */
+function createMockFetch() {
+  const calls = { auth: 0, scopes: 0, dataApi: 0 };
+  const fn = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = input.toString();
+
+    if (url.startsWith(TEST_SERVER_PREFIX)) {
+      return originalFetch(input as never, init);
+    }
+    if (url.includes("/auth/external")) {
+      calls.auth++;
+      return jsonResponse(200, {
+        success: true,
+        data: { token: "mock-checkpoint-token", expiresIn: 1800 },
+      });
+    }
+    if (url.includes("/v1.0/scopes")) {
+      calls.scopes++;
+      return jsonResponse(200, {
+        responseEnvelope: { requestId: "scopes-req", responseCode: 200, responseText: "OK" },
+        responseData: ["mt-prod-cp-1:acme-test"],
+      });
+    }
+    calls.dataApi++;
+    return jsonResponse(200, {
+      responseEnvelope: { requestId: "data-req", responseCode: 200, responseText: "OK" },
+      responseData: [],
+    });
+  });
+  return { fn, calls };
+}
+
+function mintS2sHeader(secret: string, unixSeconds: number): string {
+  const message = `t=${unixSeconds}`;
+  const hex = createHmac("sha256", secret).update(message).digest("hex");
+  return `${message},v1=${hex}`;
+}
+
+async function postToMcp(headers: Record<string, string>, body: unknown): Promise<Response> {
+  return fetch(`${TEST_SERVER_PREFIX}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      // Streamable HTTP transport (stateless mode) requires both
+      // content types in Accept even for non-streaming JSON responses.
+      Accept: "application/json, text/event-stream",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const TOOLS_LIST_BODY = { jsonrpc: "2.0", method: "tools/list", id: 1 };
+const QUERY_EVENTS_CALL_BODY = {
+  jsonrpc: "2.0",
+  method: "tools/call",
+  params: { name: "hec_query_events", arguments: {} },
+  id: 2,
+};
+
+async function waitForServerReady(): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    try {
+      await originalFetch(`${TEST_SERVER_PREFIX}/health`);
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+  }
+  throw new Error("test HTTP server did not become ready in time");
+}
+
+beforeAll(async () => {
+  process.env.MCP_TRANSPORT = "http";
+  process.env.AUTH_MODE = "gateway";
+  process.env.MCP_HTTP_PORT = String(TEST_PORT);
+  process.env.MCP_HTTP_HOST = TEST_HOST;
+  process.env.CONDUIT_S2S_SECRET = TEST_S2S_SECRET;
+  await import("../index.js");
+  await waitForServerReady();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe("S2S guard ordering vs. lazy Checkpoint OAuth exchange", () => {
+  it("does NOT reach Checkpoint auth/scopes when the S2S header is missing", async () => {
+    const { fn, calls } = createMockFetch();
+    global.fetch = fn;
+
+    const res = await postToMcp(
+      { "x-checkpoint-client-id": "test-client", "x-checkpoint-client-secret": "test-secret" },
+      TOOLS_LIST_BODY
+    );
+
+    expect(res.status).toBe(401);
+    expect(calls.auth).toBe(0);
+    expect(calls.scopes).toBe(0);
+  });
+
+  it("does NOT reach Checkpoint auth/scopes when the S2S header is present but invalid", async () => {
+    const { fn, calls } = createMockFetch();
+    global.fetch = fn;
+
+    const res = await postToMcp(
+      {
+        "x-gateway-s2s": mintS2sHeader("wrong-secret", Math.floor(Date.now() / 1000)),
+        "x-checkpoint-client-id": "test-client",
+        "x-checkpoint-client-secret": "test-secret",
+      },
+      TOOLS_LIST_BODY
+    );
+
+    expect(res.status).toBe(401);
+    expect(calls.auth).toBe(0);
+    expect(calls.scopes).toBe(0);
+  });
+
+  it("DOES reach Checkpoint auth/scopes once the S2S guard accepts and a real tool executes (negative control)", async () => {
+    const { fn, calls } = createMockFetch();
+    global.fetch = fn;
+
+    const res = await postToMcp(
+      {
+        "x-gateway-s2s": mintS2sHeader(TEST_S2S_SECRET, Math.floor(Date.now() / 1000)),
+        "x-checkpoint-client-id": "test-client",
+        "x-checkpoint-client-secret": "test-secret",
+      },
+      QUERY_EVENTS_CALL_BODY
+    );
+
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as { result?: { isError?: boolean } };
+    // Proves the tool call actually completed successfully end-to-end
+    // (not that it merely reached the server and errored out before
+    // ensureAuth() could run) — otherwise a zero-calls-elsewhere false
+    // negative could hide behind an early error path.
+    expect(payload.result?.isError).toBeFalsy();
+
+    // The proof this negative control exists for: the mock apparatus CAN
+    // detect refreshToken()/refreshScopes() firing, so the zero-calls
+    // assertions in the two tests above aren't vacuously true.
+    expect(calls.auth).toBe(1);
+    expect(calls.scopes).toBe(1);
+    expect(calls.dataApi).toBe(1);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,13 @@ import { searchTools, handleSearchTool } from "./tools/search.js";
 import { actionTools, handleActionTool } from "./tools/actions.js";
 import { exceptionTools, handleExceptionTool } from "./tools/exceptions.js";
 import type { CallToolResult } from "./utils/types.js";
+import { verifyS2sHeader, S2S_HEADER } from "./s2s-verify.js";
+
+// Conduit service-to-service auth (gateway#377 parity). Non-empty =
+// enforce X-Gateway-S2S on every /mcp request; empty = disabled, behavior
+// exactly as before (dark-by-default until the gateway provisions this
+// container's derived subkey). See src/s2s-verify.ts.
+const S2S_SECRET = process.env.CONDUIT_S2S_SECRET || "";
 
 const ALL_TOOLS = [...eventTools, ...searchTools, ...actionTools, ...exceptionTools];
 
@@ -130,6 +137,16 @@ async function startHttpTransport(): Promise<void> {
     }
 
     if (url.pathname === "/mcp") {
+      if (S2S_SECRET && !verifyS2sHeader(req.headers[S2S_HEADER] as string | undefined, S2S_SECRET)) {
+        res.writeHead(401, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            error: "Missing or invalid X-Gateway-S2S header: this endpoint only accepts requests signed by the gateway.",
+          })
+        );
+        return;
+      }
+
       // Extract per-request credentials from headers (gateway mode).
       // Credentials are stored in AsyncLocalStorage so concurrent
       // requests are isolated — no process.env mutation.

--- a/src/s2s-verify.test.ts
+++ b/src/s2s-verify.test.ts
@@ -15,21 +15,24 @@ describe("verifyS2sHeader", () => {
   const MASTER = "test-master-secret-do-not-use-in-prod";
   const ownSubkey = deriveRecipientSubkey(MASTER, "avanan");
   const siblingSubkey = deriveRecipientSubkey(MASTER, "abnormal");
-  const now = Math.floor(Date.now() / 1000);
-
   it("accepts a header minted with this vendor's own derived subkey", () => {
+    const now = Math.floor(Date.now() / 1000);
     expect(verifyS2sHeader(mintHeader(ownSubkey, now), ownSubkey)).toBe(true);
   });
   it("REJECTS a header minted for a different vendor's derived subkey (recipient-binding proof)", () => {
+    const now = Math.floor(Date.now() / 1000);
     expect(verifyS2sHeader(mintHeader(siblingSubkey, now), ownSubkey)).toBe(false);
   });
   it("rejects a stale timestamp outside the skew window", () => {
+    const now = Math.floor(Date.now() / 1000);
     expect(verifyS2sHeader(mintHeader(ownSubkey, now - 301), ownSubkey)).toBe(false);
   });
   it("rejects a future timestamp outside the skew window", () => {
+    const now = Math.floor(Date.now() / 1000);
     expect(verifyS2sHeader(mintHeader(ownSubkey, now + 301), ownSubkey)).toBe(false);
   });
   it("accepts a timestamp at the edge of the skew window", () => {
+    const now = Math.floor(Date.now() / 1000);
     expect(verifyS2sHeader(mintHeader(ownSubkey, now - 300), ownSubkey)).toBe(true);
   });
   it("rejects a malformed header value", () => {
@@ -39,9 +42,11 @@ describe("verifyS2sHeader", () => {
     expect(verifyS2sHeader(undefined, ownSubkey)).toBe(false);
   });
   it("rejects when the secret is empty (dark-by-default guarantee)", () => {
+    const now = Math.floor(Date.now() / 1000);
     expect(verifyS2sHeader(mintHeader(ownSubkey, now), "")).toBe(false);
   });
   it("rejects a tampered signature", () => {
+    const now = Math.floor(Date.now() / 1000);
     const header = mintHeader(ownSubkey, now);
     const tampered = header.slice(0, -1) + (header.endsWith("0") ? "1" : "0");
     expect(verifyS2sHeader(tampered, ownSubkey)).toBe(false);

--- a/src/s2s-verify.test.ts
+++ b/src/s2s-verify.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { createHmac } from "node:crypto";
+import { verifyS2sHeader } from "./s2s-verify.js";
+
+function deriveRecipientSubkey(masterSecret: string, slug: string): string {
+  return createHmac("sha256", masterSecret).update(`s2s-recipient:${slug}`).digest("hex");
+}
+function mintHeader(secret: string, unixSeconds: number): string {
+  const message = `t=${unixSeconds}`;
+  const hex = createHmac("sha256", secret).update(message).digest("hex");
+  return `${message},v1=${hex}`;
+}
+
+describe("verifyS2sHeader", () => {
+  const MASTER = "test-master-secret-do-not-use-in-prod";
+  const ownSubkey = deriveRecipientSubkey(MASTER, "avanan");
+  const siblingSubkey = deriveRecipientSubkey(MASTER, "abnormal");
+  const now = Math.floor(Date.now() / 1000);
+
+  it("accepts a header minted with this vendor's own derived subkey", () => {
+    expect(verifyS2sHeader(mintHeader(ownSubkey, now), ownSubkey)).toBe(true);
+  });
+  it("REJECTS a header minted for a different vendor's derived subkey (recipient-binding proof)", () => {
+    expect(verifyS2sHeader(mintHeader(siblingSubkey, now), ownSubkey)).toBe(false);
+  });
+  it("rejects a stale timestamp outside the skew window", () => {
+    expect(verifyS2sHeader(mintHeader(ownSubkey, now - 301), ownSubkey)).toBe(false);
+  });
+  it("rejects a future timestamp outside the skew window", () => {
+    expect(verifyS2sHeader(mintHeader(ownSubkey, now + 301), ownSubkey)).toBe(false);
+  });
+  it("accepts a timestamp at the edge of the skew window", () => {
+    expect(verifyS2sHeader(mintHeader(ownSubkey, now - 300), ownSubkey)).toBe(true);
+  });
+  it("rejects a malformed header value", () => {
+    expect(verifyS2sHeader("not-a-valid-header", ownSubkey)).toBe(false);
+  });
+  it("rejects a missing header", () => {
+    expect(verifyS2sHeader(undefined, ownSubkey)).toBe(false);
+  });
+  it("rejects when the secret is empty (dark-by-default guarantee)", () => {
+    expect(verifyS2sHeader(mintHeader(ownSubkey, now), "")).toBe(false);
+  });
+  it("rejects a tampered signature", () => {
+    const header = mintHeader(ownSubkey, now);
+    const tampered = header.slice(0, -1) + (header.endsWith("0") ? "1" : "0");
+    expect(verifyS2sHeader(tampered, ownSubkey)).toBe(false);
+  });
+});

--- a/src/s2s-verify.ts
+++ b/src/s2s-verify.ts
@@ -1,0 +1,43 @@
+/**
+ * Verifies the conduit gateway's service-to-service auth header
+ * (gateway#377 parity — closes the confused-deputy gap where a compromised
+ * sibling sidecar in the shared ACA environment could otherwise impersonate
+ * the gateway to this container).
+ *
+ * This is a near-verbatim port of conduit's `verifyS2sHeader`
+ * (src/proxy/s2s.ts) — intentionally unchanged logic, ported once and kept
+ * in sync. `secret` is treated as an opaque value: since gateway#377
+ * Finding B, the gateway derives a per-vendor subkey from its master
+ * secret and this container is provisioned (via CONDUIT_S2S_SECRET) with
+ * only its own derived value, never the raw master — a sibling sidecar
+ * holds a DIFFERENT derived value and cannot forge a header that verifies
+ * here. This function doesn't need to know that; it just checks whatever
+ * secret it's handed.
+ *
+ * Empty secret => always returns false. The caller is expected to treat an
+ * empty CONDUIT_S2S_SECRET as "S2S enforcement disabled" (dark-by-default,
+ * matches the dormant/pre-provisioning state) rather than calling this at
+ * all — see the enforcement check in index.ts.
+ */
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/** Request header carrying the S2S proof. Node lowercases incoming header names. */
+export const S2S_HEADER = "x-gateway-s2s";
+
+const HEADER_VALUE_RE = /^t=(\d{1,15}),v1=([0-9a-f]{64})$/;
+
+export function verifyS2sHeader(
+  headerValue: string | undefined,
+  secret: string,
+  maxSkewSeconds = 300
+): boolean {
+  if (!secret || !headerValue) return false;
+  const match = HEADER_VALUE_RE.exec(headerValue);
+  if (!match) return false;
+  const t = Number(match[1]);
+  if (!Number.isSafeInteger(t)) return false;
+  if (Math.abs(Math.floor(Date.now() / 1000) - t) > maxSkewSeconds) return false;
+  const expected = createHmac("sha256", secret).update(`t=${t}`).digest();
+  const provided = Buffer.from(match[2], "hex");
+  return provided.length === expected.length && timingSafeEqual(provided, expected);
+}


### PR DESCRIPTION
## Summary

Mechanical-wave port of conduit gateway#377's confused-deputy fix to this vendor sidecar, following the S1 pattern already live-validated on xero-mcp#54, mimecast-mcp#55, and liongard-mcp#60. This is a near-verbatim port of conduit's `verifyS2sHeader` (src/proxy/s2s.ts) — intentionally unchanged logic, ported once and kept in sync.

- Added `src/s2s-verify.ts` (byte-for-byte identical to the validated reference used in the other ported repos).
- In `src/index.ts`, added the `CONDUIT_S2S_SECRET` env-gated check as the absolute first statement inside the `if (url.pathname === "/mcp")` block — before any credential extraction (`x-checkpoint-client-id` / `x-checkpoint-client-secret`) or gateway-mode logic.
- Dark-by-default: with `CONDUIT_S2S_SECRET` unset/empty, behavior is unchanged from before this PR.
- Added `src/s2s-verify.test.ts` covering accept/reject cases, skew-window edges, malformed/missing/tampered headers, empty-secret dark-by-default, and cross-vendor subkey rejection (avanan vs. abnormal).

## Test plan

- `npx tsc --noEmit` — clean, no errors.
- `npm run build` — clean, no errors.
- Tests present and run locally (31/31 passing, 3 test files, including the new `s2s-verify.test.ts`). This repo has no CI workflow running the test suite at all — `mcp-assert.yml` (the only PR-triggered workflow besides `release.yml`) is a contract/canary check only, not a test runner. Verified via `.github/workflows/` listing. Fleet-wide CI-hygiene item tracked separately (murph).

## Review note

**Do not merge without Walter + boss review — auth surface, heightened-review-and-narrate tier.**
